### PR TITLE
Propagate forInit down to arrow functions

### DIFF
--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -521,7 +521,7 @@ const FUNC_STATEMENT = 1, FUNC_HANGING_STATEMENT = 2, FUNC_NULLABLE_ID = 4
 // `statement & FUNC_STATEMENT`).
 
 // Remove `allowExpressionBody` for 7.0.0, as it is only called with false
-pp.parseFunction = function(node, statement, allowExpressionBody, isAsync) {
+pp.parseFunction = function(node, statement, allowExpressionBody, isAsync, forInit) {
   this.initFunction(node)
   if (this.options.ecmaVersion >= 9 || this.options.ecmaVersion >= 6 && !isAsync) {
     if (this.type === tt.star && (statement & FUNC_HANGING_STATEMENT))
@@ -551,7 +551,7 @@ pp.parseFunction = function(node, statement, allowExpressionBody, isAsync) {
     node.id = this.type === tt.name ? this.parseIdent() : null
 
   this.parseFunctionParams(node)
-  this.parseFunctionBody(node, allowExpressionBody, false)
+  this.parseFunctionBody(node, allowExpressionBody, false, forInit)
 
   this.yieldPos = oldYieldPos
   this.awaitPos = oldAwaitPos
@@ -751,7 +751,7 @@ pp.parseClassId = function(node, isStatement) {
 }
 
 pp.parseClassSuper = function(node) {
-  node.superClass = this.eat(tt._extends) ? this.parseExprSubscripts() : null
+  node.superClass = this.eat(tt._extends) ? this.parseExprSubscripts(false) : null
 }
 
 pp.enterClassBody = function() {

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -16624,3 +16624,257 @@ test("let \u0061;", {}, {ecmaVersion: 6})
 test("let in\u0061;", {}, {ecmaVersion: 6})
 test("let in𝐬𝐭𝐚𝐧𝐜𝐞𝐨𝐟;", {}, {ecmaVersion: 6})
 test("let 𝐢𝐧;", {}, {ecmaVersion: 6})
+
+testFail("for (let a = b => b in c;;);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
+testFail("for (let a = b => c => d in e;;);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
+testFail("for (var a = b => c in d;;);", "Unexpected token (1:24)", { ecmaVersion: 8 })
+testFail("for (var a = b => c => d in e;;);", "Unexpected token (1:29)", { ecmaVersion: 8 })
+testFail("for (x => x in y;;);", "Assigning to rvalue (1:5)", { ecmaVersion: 6 })
+testFail("for (x => y => y in z;;);", "Assigning to rvalue (1:5)", { ecmaVersion: 6 })
+test("for ((a in b);;);", {
+  type: "Program",
+  start: 0,
+  end: 17,
+  loc: {
+    start: {
+      line: 1,
+      column: 0
+    },
+    end: {
+      line: 1,
+      column: 17
+    }
+  },
+  body: [
+    {
+      type: "ForStatement",
+      start: 0,
+      end: 17,
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 1,
+          column: 17
+        }
+      },
+      init: {
+        type: "BinaryExpression",
+        start: 6,
+        end: 12,
+        loc: {
+          start: {
+            line: 1,
+            column: 6
+          },
+          end: {
+            line: 1,
+            column: 12
+          }
+        },
+        left: {
+          type: "Identifier",
+          start: 6,
+          end: 7,
+          loc: {
+            start: {
+              line: 1,
+              column: 6
+            },
+            end: {
+              line: 1,
+              column: 7
+            }
+          },
+          name: "a"
+        },
+        operator: "in",
+        right: {
+          type: "Identifier",
+          start: 11,
+          end: 12,
+          loc: {
+            start: {
+              line: 1,
+              column: 11
+            },
+            end: {
+              line: 1,
+              column: 12
+            }
+          },
+          name: "b"
+        }
+      },
+      test: null,
+      update: null,
+      body: {
+        type: "EmptyStatement",
+        start: 16,
+        end: 17,
+        loc: {
+          start: {
+            line: 1,
+            column: 16
+          },
+          end: {
+            line: 1,
+            column: 17
+          }
+        }
+      }
+    }
+  ],
+}, { locations: true })
+
+test("for (function (){ a in b };;);", {
+  type: "Program",
+  start: 0,
+  end: 30,
+  loc: {
+    start: {
+      line: 1,
+      column: 0
+    },
+    end: {
+      line: 1,
+      column: 30
+    }
+  },
+  body: [
+    {
+      type: "ForStatement",
+      start: 0,
+      end: 30,
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 1,
+          column: 30
+        }
+      },
+      init: {
+        type: "FunctionExpression",
+        start: 5,
+        end: 26,
+        loc: {
+          start: {
+            line: 1,
+            column: 5
+          },
+          end: {
+            line: 1,
+            column: 26
+          }
+        },
+        id: null,
+        expression: false,
+        generator: false,
+        async: false,
+        params: [],
+        body: {
+          type: "BlockStatement",
+          start: 16,
+          end: 26,
+          loc: {
+            start: {
+              line: 1,
+              column: 16
+            },
+            end: {
+              line: 1,
+              column: 26
+            }
+          },
+          body: [
+            {
+              type: "ExpressionStatement",
+              start: 18,
+              end: 24,
+              loc: {
+                start: {
+                  line: 1,
+                  column: 18
+                },
+                end: {
+                  line: 1,
+                  column: 24
+                }
+              },
+              expression: {
+                type: "BinaryExpression",
+                start: 18,
+                end: 24,
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 18
+                  },
+                  end: {
+                    line: 1,
+                    column: 24
+                  }
+                },
+                left: {
+                  type: "Identifier",
+                  start: 18,
+                  end: 19,
+                  loc: {
+                    start: {
+                      line: 1,
+                      column: 18
+                    },
+                    end: {
+                      line: 1,
+                      column: 19
+                    }
+                  },
+                  name: "a"
+                },
+                operator: "in",
+                right: {
+                  type: "Identifier",
+                  start: 23,
+                  end: 24,
+                  loc: {
+                    start: {
+                      line: 1,
+                      column: 23
+                    },
+                    end: {
+                      line: 1,
+                      column: 24
+                    }
+                  },
+                  name: "b"
+                }
+              }
+            }
+          ]
+        }
+      },
+      test: null,
+      update: null,
+      body: {
+        type: "EmptyStatement",
+        start: 29,
+        end: 30,
+        loc: {
+          start: {
+            line: 1,
+            column: 29
+          },
+          end: {
+            line: 1,
+            column: 30
+          }
+        }
+      }
+    }
+  ]
+}, { locations: true, ecmaVersion: 8, })


### PR DESCRIPTION
FIX: Fix an issue where arrow function bodies in for loop context would inappropriately consume `in` operators.

Issue #1058
Issue #838
Issue #922